### PR TITLE
updating org.eclipse.jgit version to fix dependabot alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>5.13.3.202401111512-r</version>
+            <version>6.10.1.202505221210-r</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.features</groupId>


### PR DESCRIPTION
Fixes https://github.com/WASdev/slsa-maven-plugin/security/dependabot/2